### PR TITLE
move browser dependent calculations to componentDidMount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ class Columns extends Component{
     })
   }
 
-  componentWillMount() {
+  componentDidMount() {
     if (this.props.queries.length) {
       this._columns = mediaQueryMapper({
         queries: this.props.queries,


### PR DESCRIPTION
ComponentWillMount runs when doing server side rendering, since there's no window in the node environment it'll throw an error. Simply moving the call to componentDidMount makes server side rendering work.