### PR TITLE
Run rename-unsafe-lifecycles codemod

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ class Columns extends Component{
     this.updateColumns(this.props);
   }
 
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     const queriesChanged = this.props.queries !== nextProps.queries;
     const columnsChanged = this.props.columns !== nextProps.columns
     if (queriesChanged || columnsChanged) {


### PR DESCRIPTION
This change was created by running `npx react-codemod rename-unsafe-lifecycles`. It changed `componentWillReceiveProps` to `UNSAFE_componentWillReceiveProps`. If you want to use `componentDidUpdate` instead, use it and close this PR.